### PR TITLE
Rename native libraries to avoid collision when publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: linux-x64
-          path: build/libInstanceTrampoline.so
+          path: build/libInstanceTrampolineNative.so
           if-no-files-found: error
 
   build-osx:
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: macos-${{ matrix.name }}
-          path: build/libInstanceTrampoline.dylib
+          path: build/libInstanceTrampolineNative.dylib
           if-no-files-found: error
 
   build-windows-x64:
@@ -84,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-x64
-          path: build/Release/InstanceTrampoline.dll
+          path: build/Release/InstanceTrampolineNative.dll
           if-no-files-found: error
 
   publish:

--- a/InstanceTrampoline/InstanceTrampoline.cs
+++ b/InstanceTrampoline/InstanceTrampoline.cs
@@ -11,13 +11,13 @@ namespace InstanceTrampoline
         /// <summary>
         /// Get the delegate for the allocate_trampoline method in the native library.
         /// </summary>
-        [DllImport("InstanceTrampoline",CallingConvention = CallingConvention.Cdecl,EntryPoint = "allocate_trampoline")]
+        [DllImport("InstanceTrampolineNative",CallingConvention = CallingConvention.Cdecl,EntryPoint = "allocate_trampoline")]
         public extern static nint AllocateTrampoline(nint instance, int numParams, nint method);
 
         /// <summary>
         /// Get the delegate for the allocate_printer method in the native library.
         /// </summary>
-        [DllImport("InstanceTrampoline", CallingConvention = CallingConvention.Cdecl, EntryPoint = "allocate_printer")]
+        [DllImport("InstanceTrampolineNative", CallingConvention = CallingConvention.Cdecl, EntryPoint = "allocate_printer")]
         public extern static nint AllocatePrinter(nint method);
 
     }

--- a/InstanceTrampoline/InstanceTrampoline.csproj
+++ b/InstanceTrampoline/InstanceTrampoline.csproj
@@ -21,8 +21,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageID>SavourySnaX.InstanceTrampoline</PackageID>
-    <Version>8.0.1</Version>
-    <PackageVersion>8.0.1</PackageVersion>
+    <Version>8.0.2</Version>
+    <PackageVersion>8.0.2</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Native/CMakeLists.txt
+++ b/Native/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 3.0.0)
-project(InstanceTrampoline VERSION 0.1.0)
+project(InstanceTrampolineNative VERSION 0.1.1)
 
 list(APPEND SOURCES "JITBuffer.cpp" "NativeInterface.cpp" "NativeTrampoline.cpp")
 list(APPEND SOURCES "JITBuffer.h" "NativeInterface.h")
 list(APPEND SOURCES "NativeTrampoline.h" "platform.h")
 list(APPEND SOURCES "NativeTrampolineSystemVAarch64.h" "NativeTrampolineSystemVX64.h" "NativeTrampolineWindowsX64.h")
 
-add_library(InstanceTrampoline SHARED ${SOURCES})
+add_library(InstanceTrampolineNative SHARED ${SOURCES})
 
 if (WIN32)
-    set_property(TARGET InstanceTrampoline PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+	set_property(TARGET InstanceTrampolineNative PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
-set_property(TARGET InstanceTrampoline PROPERTY CXX_STANDARD 17)
+set_property(TARGET InstanceTrampolineNative PROPERTY CXX_STANDARD 17)


### PR DESCRIPTION
Both the managed and the native dlls where named the same, this renames the native ones.